### PR TITLE
node-appwrite upgrade and better support for relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 types/
 node_modules/
 config.json
+.vscode/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appwrite-typer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CLI tool to generate Typescript definitions for your Appwrite collections.",
   "main": "index.js",
   "type": "module",
@@ -19,7 +19,7 @@
   "dependencies": {
     "camelcase": "^8.0.0",
     "ejs": "^3.1.9",
-    "node-appwrite": "^11.1.0",
+    "node-appwrite": "^13.0.0",
     "process": "^0.11.10",
     "yargs": "^17.7.2"
   }

--- a/template.ejs
+++ b/template.ejs
@@ -1,8 +1,5 @@
-
 export interface <%= getTypeFormatted(name) %> extends Models.Document {
 <%_ attributes.forEach(attribute => { -%>
-    <%= attribute.name _%>
-    <%_ if (!attribute.required) { -%>?<% } -%>: <%_ if (attribute.relation) { -%> <%- getTypeFormatted(attribute.relation) ?? 'unknown' -%> <%_ if (attribute.relationType === 'oneToMany') {-%>[]<%} -%> <%_ } -%><% if (!attribute.relation) { -%> <%- getType(attribute.type) ?? 'unknown' -%> <%_ } -%>
-    <%_ if (attribute.array) { -%>[]<% } -%>;
-<% }); -%>
+    <%= attribute.name _%><%_ if (!attribute.required) { -%>?<%_ } -%>: <% if (attribute.relation) { -%><%- getRelationshipType(attribute) _%><%_ } else { -%><%- getType(attribute.type) ?? 'unknown' _%><%_ } _%><%_ if (attribute.array) { -%>[]<%_ } _%>;
+<%_ }); -%>
 };

--- a/typescript.js
+++ b/typescript.js
@@ -25,11 +25,30 @@ export class Typescript {
         return "Date";
       case AttributeTypes.RELATIONSHIP:
         return type;
+      default:
+        return "unknown";
     }
   }
 
   static getTypeFormatted(name) {
     return camelcase(name, { pascalCase: true });
+  }
+
+  static getRelationshipType(attribute) {
+    if (!attribute.relation) return 'unknown';
+    
+    const baseType = Typescript.getTypeFormatted(attribute.relation);
+    
+    switch (attribute.relationType) {
+      case 'oneToOne':
+      case 'manyToOne':
+        return baseType;
+      case 'oneToMany':
+      case 'manyToMany':
+        return `${baseType}[]`;
+      default:
+        return 'unknown';
+    }
   }
 
   getTypeDefault(attribute) {


### PR DESCRIPTION
Upgraded node-appwrite to version 13, and added better support for different relation types. Mainly, ManyToMany did not seem to correctly generate the attribute types as arrays in the output file.