### PR TITLE
feat: typescript enums

### DIFF
--- a/template.ejs
+++ b/template.ejs
@@ -1,5 +1,0 @@
-export interface <%= getTypeFormatted(name) %> extends Models.Document {
-<%_ attributes.forEach(attribute => { -%>
-    <%= attribute.name _%><%_ if (!attribute.required) { -%>?<%_ } -%>: <% if (attribute.relation) { -%><%- getRelationshipType(attribute) _%><%_ } else { -%><%- getType(attribute.type) ?? 'unknown' _%><%_ } _%><%_ if (attribute.array) { -%>[]<%_ } _%>;
-<%_ }); -%>
-};

--- a/templates/enum.ejs
+++ b/templates/enum.ejs
@@ -1,0 +1,7 @@
+export const <%= enumFormatted %> = {
+    <%_ elements.forEach(element => { -%>
+    '<%= element _%>': '<%= element _%>',
+    <%_ }); -%>
+} as const;
+  
+export type <%= enumFormatted %> = (typeof <%= enumFormatted %>)[keyof typeof <%= enumFormatted %>];

--- a/templates/interface.ejs
+++ b/templates/interface.ejs
@@ -1,0 +1,5 @@
+export interface <%= typeFormatted %> extends Partial<Models.Document> {
+<%_ attributes.forEach(attribute => { -%>
+    <%= attribute.name _%><%_ if (!attribute.required) { -%>?<%_ } -%>: <% if (attribute.relation) { -%><%- getRelationshipType(attribute) _%><%_ } else { -%><%- getType(attribute) ?? 'unknown' _%><%_ } _%><%_ if (attribute.array) { -%>[]<%_ } _%>;
+<%_ }); -%>
+};

--- a/typescript.js
+++ b/typescript.js
@@ -9,67 +9,65 @@ const AttributeTypes = {
   RELATIONSHIP: "relationship",
 };
 
+const FormatTypes = {
+  ENUM: "enum",
+  EMAIL: "email",
+  URL: "url",
+};
+
 export class Typescript {
-  static getType(type) {
-    console.log({ type });
-    switch (type) {
-      case AttributeTypes.STRING:
-        return "string";
-      case AttributeTypes.INTEGER:
-        return "number";
-      case AttributeTypes.DOUBLE:
-        return "number";
-      case AttributeTypes.BOOLEAN:
-        return "boolean";
-      case AttributeTypes.DATETIME:
-        return "Date";
-      case AttributeTypes.RELATIONSHIP:
-        return type;
+  static getCamelCase(input) {
+    return camelcase(input, { pascalCase: true });
+  }
+
+  static getType(attribute) {
+    const getPrimitive = (type) => {
+      switch (type) {
+        case AttributeTypes.STRING:
+          return "string";
+        case AttributeTypes.INTEGER:
+          return "number";
+        case AttributeTypes.DOUBLE:
+          return "number";
+        case AttributeTypes.BOOLEAN:
+          return "boolean";
+        case AttributeTypes.DATETIME:
+          return "Date";
+        default:
+          return "unknown";
+      }
+    };
+
+    switch (attribute.format) {
+      case FormatTypes.ENUM:
+        return Typescript.getEnumFormatted(attribute);
       default:
-        return "unknown";
+        return getPrimitive(attribute.type);
     }
   }
 
-  static getTypeFormatted(name) {
-    return camelcase(name, { pascalCase: true });
+  static getEnumFormatted({ collection, name }) {
+    return Typescript.getCamelCase(collection) + Typescript.getCamelCase(name);
+  }
+
+  static getTypeFormatted({ name }) {
+    return Typescript.getCamelCase(name);
   }
 
   static getRelationshipType(attribute) {
-    if (!attribute.relation) return 'unknown';
-    
-    const baseType = Typescript.getTypeFormatted(attribute.relation);
-    
+    if (!attribute.relation) return "unknown";
+
+    const baseType = Typescript.getCamelCase(attribute.relation);
+
     switch (attribute.relationType) {
-      case 'oneToOne':
-      case 'manyToOne':
+      case "oneToOne":
+      case "manyToOne":
         return baseType;
-      case 'oneToMany':
-      case 'manyToMany':
+      case "oneToMany":
+      case "manyToMany":
         return `${baseType}[]`;
       default:
-        return 'unknown';
-    }
-  }
-
-  getTypeDefault(attribute) {
-    if (!attribute.required) {
-      return "null";
-    }
-    if (attribute.array) {
-      return "[]";
-    }
-
-    switch (attribute.type) {
-      case AttributeTypes.STRING:
-        return "string";
-      case AttributeTypes.INTEGER:
-        return "number";
-      case AttributeTypes.DOUBLE:
-        return "number";
-      case AttributeTypes.BOOLEAN:
-        return "boolean";
-      case AttributeTypes.DATETIME:
-        return "Date";
+        return "unknown";
     }
   }
 


### PR DESCRIPTION
1. Added enum support (using consts not enums - https://dev.to/ivanzm123/dont-use-enums-in-typescript-they-are-very-dangerous-57bh)

2. Added partial for Models.Document (because when creating an entity in the database we don't need $id and other fields, so don't let it cause conflicts)

Result:

```
import type { Models } from "appwrite";

export const SampleEnum = {
  a: "a",
  b: "b",
  "c/d": "c/d",
} as const;

export type SampleEnum = (typeof SampleEnum)[keyof typeof SampleEnum];

export interface Sample extends Partial<Models.Document> {
  INT: number;
  STRING?: string;
  FLOAT?: number;
  BOOL?: boolean;
  DATE?: Date;
  EMAIL?: string;
  URL?: string;
  ENUM?: SampleEnum;
  FLOAT_ARR?: number[];
}
```